### PR TITLE
fix install problem

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,8 +5,7 @@
   "main": "index.js",
   "scripts": {
     "test": "webpack-dev-server --config test/webpack.config.js",
-    "copy": "cp node_modules/ember/ember-template-compiler.js ./ember-template-compiler.js",
-    "install": "napa"
+    "copy": "cp node_modules/ember/ember-template-compiler.js ./ember-template-compiler.js"
   },
   "author": "Kyle Robinson Young <kyle@dontkry.com> (http://dontkry.com)",
   "license": "MIT",


### PR DESCRIPTION
Since `napa` isn't included in deps anymore, this throws an error during install.

I'm currently using this branch on my project to get past this problem.