### PR TITLE
Allow passing a compiler to ember-templates-loader

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,12 @@ module.exports = {
     loaders: [
       { test: /\.hbs$/, loader: 'ember-templates' }
     ]
+  },
+  emberTemplatesLoader: {
+    // Where to require the compiler from, defaults to an internal compiler.
+    compiler: 'ember/ember-template-compiler',
+    // OR: Pass in the precompiler directly...
+    // precompile: require('ember/ember-template-compiler').precompile,
   }
 };
 ```

--- a/index.js
+++ b/index.js
@@ -1,6 +1,13 @@
-var precompile = require('./ember-template-compiler').precompile;
 module.exports = function(source) {
+  var options = this.options.emberTemplatesLoader || {};
+  var precompile = options.precompile;
+  if (!precompile) {
+    precompile = require(options.compiler || './ember-template-compiler').precompile;
+  }
+
   this.cacheable && this.cacheable();
+
   return 'module.exports = Ember.HTMLBars.template(' + precompile(source) + ');';
-}
+};
+
 module.exports.seperable = true;


### PR DESCRIPTION
I wanted to break our bad-pattern of releasing for every ember that I started us down.

This solution allows you to pass either `precompile` as a function directly, or a require path.  Instructions added to the [README.md](https://github.com/shama/ember-templates-loader/pull/11/files?short_path=04c6e90#diff-04c6e90faac2675aa89e2176d2eec7d8).

Couple of thoughts I'm looking for @shama @mzgoddard 

1) Is one of these methods better than the other?

2) How to unit test?

Any chance either of you wants to help with that?